### PR TITLE
Fix prepositional case for -iya feminine names (Lidiya/Lidiyi)

### DIFF
--- a/lib/Lingua/RU/Inflect.pm
+++ b/lib/Lingua/RU/Inflect.pm
@@ -315,7 +315,7 @@ sub _inflect_given_name {
             }
         }
 
-        last if $firstname =~ s/ия$/qw(ии ии ию ией ие)[$case]/e;
+        last if $firstname =~ s/ия$/qw(ии ии ию ией ии)[$case]/e;
         last if $firstname =~ s/я$/qw(и е ю ей е)[$case]/e;
 
         # Same endings, but different gender

--- a/t/02-inflect.t
+++ b/t/02-inflect.t
@@ -272,6 +272,9 @@ ok( join(' ', f( DATIVE, 'Купер', 'Элис' ))
 ok( join(' ', f( ACCUSATIVE, 'Петрова', 'Женя' ))
     eq 'Петрову Женю ',
     'Accusative of ambiguous name, detect by lastname: Zhenya Petrova' );
+ok( join(' ', f( PREPOSITIONAL, 'Петрова', 'Евгения' ))
+    eq 'Петровой Евгении ',
+    'Prepositional of feminine names ending in -iya' );
 # Too complex. Wait for next version.
 # ok( join(' ', f( INSTRUMENTAL, 'Фишер', 'Анна-Мария' ))
 #     eq 'Фишер Анну-Марию ',


### PR DESCRIPTION
Changed prepositional case from "-iye" to "-ii" for names like Lidiya, Evgeniya etc.

See [morpher.ru](http://morpher.ru/Demo.aspx?s=%u0411%u0438%u0437%u043d%u0435%u0441-%u043b%u0435%u0434%u0438) results for these names.